### PR TITLE
use strftime('%c', localtime()) instead of %z

### DIFF
--- a/autoload/jikoku.vim
+++ b/autoload/jikoku.vim
@@ -24,9 +24,8 @@ function! s:add(ltime, utc, filename, line, col, mode)
 endfunction
 
 function! s:utc(time)
-  " @mattn, @raa0121, @itchyny and @tyru give very useful advices.
-  let tz = str2nr(matchstr(strftime('%z', a:time), '\v[+-]\zs[0-9]{2}\ze[0-9]'))
-  let tz_sec = tz * 60 * 60
+  let item = map(split(split(strftime('%c', '0'), ' ')[1], '[^0-9]'), 'str2nr(v:val)')
+  let tz_sec = item[0] * 60 * 60 + item[1] * 60
   return a:time - tz_sec
 endfunction
 


### PR DESCRIPTION
%z on Windows return '東京 (標準時)'

strftime('%c', 0) must be epoch based on 1970/1/1 0:0:0, so hours and minutes
must be time offset.
